### PR TITLE
Feature/remove old datastore implementation

### DIFF
--- a/ioc_module.js
+++ b/ioc_module.js
@@ -6,7 +6,7 @@ const extensionDiscoveryTag = require('@essential-projects/core_contracts').Exte
 function registerInContainer(container) {
 
   container.register('HttpExtension', HttpExtension)
-    .dependencies('container', 'MessageBusAdapter')
+    .dependencies('container')
     .configure('http:http_extension')
     .tags(extensionDiscoveryTag)
     .singleton();

--- a/ioc_module.js
+++ b/ioc_module.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const HttpExtension = require('./dist/commonjs/index').HttpExtension;
-const extensionDiscoveryTag = require('@essential-projects/core_contracts').ExtensionDiscoveryTag;
+const extensionDiscoveryTag = require('@essential-projects/bootstrapper_contracts').ExtensionDiscoveryTag;
 
 function registerInContainer(container) {
 

--- a/ioc_module.js
+++ b/ioc_module.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const HttpExtension = require('./dist/commonjs/index').HttpExtension;
-const extensionDiscoveryTag = require('@essential-projects/bootstrapper_contracts').ExtensionDiscoveryTag;
+const extensionDiscoveryTag = require('@essential-projects/bootstrapper_contracts').extensionDiscoveryTag;
 
 function registerInContainer(container) {
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "Simon Reymann <simon.reymann@quantusflow.com>"
   ],
   "dependencies": {
+    "@essential-projects/bootstrapper_contracts": "feature~remove_old_datastore_implementation",
     "@essential-projects/http_node": "^2.0.0",
     "@essential-projects/iam_contracts": "^3.0.0",
     "addict-ioc": "^2.3.7",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   ],
   "dependencies": {
     "@essential-projects/bootstrapper_contracts": "feature~remove_old_datastore_implementation",
-    "@essential-projects/http_node": "^2.0.0",
+    "@essential-projects/http_node": "feature~remove_old_datastore_implementation",
     "@essential-projects/iam_contracts": "^3.0.0",
     "addict-ioc": "^2.3.7",
     "body-parser": "^1.15.2",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "3.0.0",
+  "version": "4.0.0",
   "description": "extension for discovering and mounting components to an HTTP endpoint",
   "license": "MIT",
   "main": "dist/commonjs/index.js",
@@ -15,10 +15,8 @@
     "Simon Reymann <simon.reymann@quantusflow.com>"
   ],
   "dependencies": {
-    "@essential-projects/foundation": "^1.0.0",
     "@essential-projects/http_node": "^2.0.0",
     "@essential-projects/iam_contracts": "^3.0.0",
-    "@essential-projects/messagebus_contracts": "^2.0.0",
     "addict-ioc": "^2.3.7",
     "body-parser": "^1.15.2",
     "compression": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "Simon Reymann <simon.reymann@quantusflow.com>"
   ],
   "dependencies": {
-    "@essential-projects/bootstrapper_contracts": "feature~remove_old_datastore_implementation",
-    "@essential-projects/http_node": "feature~remove_old_datastore_implementation",
+    "@essential-projects/bootstrapper_contracts": "^1.0.0",
+    "@essential-projects/http_node": "^3.0.0",
     "@essential-projects/iam_contracts": "^3.0.0",
     "addict-ioc": "^2.3.7",
     "body-parser": "^1.15.2",

--- a/src/http_extension.ts
+++ b/src/http_extension.ts
@@ -1,6 +1,6 @@
 import {HttpExtension as BaseHttpExtension} from '@essential-projects/http_node';
 
-import {Container, IInstanceWrapper} from 'addict-ioc';
+import {IContainer, IInstanceWrapper} from 'addict-ioc';
 
 import * as bodyParser from 'body-parser';
 import * as compression from 'compression';
@@ -16,7 +16,7 @@ export class HttpExtension extends BaseHttpExtension {
 
   public config: any = undefined;
 
-  constructor(container: Container<IInstanceWrapper<any>>) {
+  constructor(container: IContainer<IInstanceWrapper<any>>) {
     super(container);
   }
 

--- a/src/http_extension.ts
+++ b/src/http_extension.ts
@@ -57,6 +57,7 @@ export class HttpExtension extends BaseHttpExtension {
     return new Promise((resolve: Function, reject: Function): void => {
       this._server = this._httpServer.listen(this.config.server.port, this.config.server.host, () => {
 
+        // Taken from the foundation project to remove the need for that package. Located in the base extension.
         this.invokeAsPromiseIfPossible(this.onStarted, this)
           .then((result: any) => {
             resolve(result);
@@ -66,30 +67,6 @@ export class HttpExtension extends BaseHttpExtension {
           });
       });
 
-    });
-  }
-
-  // Taken from the foundation, to remove the need for that package.
-  private invokeAsPromiseIfPossible(functionToInvoke: any, invocationContext: any, invocationParameter?: Array<any>): Promise<any> {
-
-    return new Promise((resolve: any, reject: any): void => {
-
-      const isValidFunction: boolean = functionToInvoke !== undefined &&
-                                       functionToInvoke !== null &&
-                                       typeof functionToInvoke === 'function';
-
-      if (!isValidFunction) {
-        return resolve();
-      }
-
-      let result: any;
-      try {
-        result = functionToInvoke.call(invocationContext, invocationParameter);
-      } catch (error) {
-        return reject(error);
-      }
-
-      resolve(result);
     });
   }
 }


### PR DESCRIPTION
## What did you change?

- Removed all references to old packages.
- Removed the usage of the messagebus, which was no longer being used anyway.
- Get Discovery tags from the new `bootstrapper_contracts` package.

## How can others test the changes?

Technically, the extension works as before, except that it does not instantiate a messagebus  any longer.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
