### PR TITLE
🐛 allow for multiple cors origins in socket.io preflight requests

### DIFF
--- a/src/http_extension.ts
+++ b/src/http_extension.ts
@@ -75,21 +75,12 @@ export class HttpExtension implements IHttpExtension {
   protected initializeServer(): void {
     this._httpServer = (http as any).Server(this.app);
 
-    const socketIoHeaders: any = {
-      'Access-Control-Allow-Headers': this.config.cors.options.allowedHeaders
-        ? this.config.cors.options.allowedHeaders.join(',')
-        : 'Content-Type, Authorization',
-      'Access-Control-Allow-Origin': this.config.cors.options.origin || '*',
-      'Access-Control-Allow-Credentials': this.config.cors.options.credentials || true,
-    };
-
     // TODO: The socket.io typings are currently very much outdated and do not contain the "handlePreflightRequest" option.
     // It is still functional, though.
+    const corsMiddleware = cors(this.config.cors.options);
     this._socketServer = socketIo(this.httpServer as any, <any> {
       handlePreflightRequest: (req: any, res: any): void => {
-        // tslint:disable-next-line:no-magic-numbers
-        res.writeHead(200, socketIoHeaders);
-        res.end();
+        corsMiddleware(req, res, res.end);
       },
     });
   }


### PR DESCRIPTION
**Changes:**

1. apply the same cors-handling that express uses to the socket.io-preflight-requests

[As described](https://www.w3.org/TR/cors/#resource-requests) by the w3c, (section 6.1.3), when supporting credentials, the `Access-Control-Allow-Origin`-Header must only contain a single value.
Chrome seems to be fine with multiple values in the preflight request, but at least Safari is not.

We can currently configure multiple origins, but only the cors-middleware we use for the express-routes handles setting the cors heaeders correctly. The cors headers are currently not handled correctly for the socket.io-preflight-request.

<img width="988" alt="Screenshot 2019-05-02 at 18 15 26" src="https://user-images.githubusercontent.com/20770029/57090098-4e283500-6d06-11e9-8ccb-78a3320ba39b.png">

This PR fixes that, by using the same cors-middleware we use for express to set the appropriate headers

PR: #14 

---

See the [examples](#example) for inspiration.

## How can others test the changes?

- configure multiple allowed origins
- try to create a socket.io-connection using safari as browser
- see how safari correctly connects to the socket server


## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).

## Example

<details>
<summary>
:warning: Before merging please click here to expand and follow the guide.
</summary>
<br>

Please use `:twisted_rightwards_arrows:` at the beginning of your merge commit title.

Example 1:

<pre>
<code>
:twisted_rightwards_arrows: :bug: Fix Wrong Text Decoration at ...
</code>
</pre>

To get your commit message, just copy the first part of this pull request.

Example 2:
<pre>
<code>
**Changes:**

- Fixes Wrong Text Decoration at ...
- Fixes some typos
- ...

**Issues:**

Closes #NumberOfFixedIssue

PR: #NumberOfThisPR
</code>
</pre>
</details>

## Emojis

<details>
<summary>
Expand for a list of most used Emojis.
</summary>
<br>

Please prefix your commit messages with an Emoji.

Ref: https://gitmoji.carloscuesta.me/

| Description              | Glyphe               | Emoji  |
|--------------------------|----------------------|--------|
| Bugfix                   | `:bug:`              | 🐛     |
| Fixing Security Issues   | `:lock:`             | 🔒     |
| Configuration releated   | `:wrench:`           | 🔧     |
| Cosmetic                 | `:lipstick:`         | 💄     |
| Dependencies Downgrade   | `:arrow_down:`       | ⬇️     |
| Dependencies Upgrade     | `:arrow_up:`         | ⬆️     |
| Formatting               | `:art:`              | 🎨     |
| Improving Performance    | `:zap:`              | ⚡️      |
| Initial commit           | `:tada:`             | 🎉     |
| Linter                   | `:rotating_light:`   | 🚨     |
| Miscellaneous            | `:package:`          | 📦     |
| New Feature              | `:sparkles:`         | ✨     |
| Refactoring Code         | `:recycle:`          | ♻️      |
| Releasing / Version tags | `:bookmark:`         | 🔖     |
| Removing Stuff           | `:fire:`             | 🔥     |
| Tests                    | `:white_check_mark:` | ✅     |
| Work In Progress (WIP)   | `:construction:`     | 🚧     |

</details>
