### PR TITLE
💄 Cleanup

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,8 +1,3 @@
 {
-  "extends": "@essential-projects/eslint-config",
-   "rules": {
-     "no-restricted-syntax": ["off"],
-     "guard-for-in": ["off"],
-     "@typescript-eslint/member-naming": ["off"]
-   }
+  "extends": "@essential-projects/eslint-config"
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "6.8.0",
+  "version": "7.0.0",
   "description": "Extension for discovering and mounting components to an HTTP- or Socket.io- endpoint.",
   "license": "MIT",
   "main": "dist/commonjs/index.js",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "6.7.3",
+  "version": "6.8.0",
   "description": "Extension for discovering and mounting components to an HTTP- or Socket.io- endpoint.",
   "license": "MIT",
   "main": "dist/commonjs/index.js",

--- a/src/error_handler.ts
+++ b/src/error_handler.ts
@@ -6,6 +6,8 @@ const logger = Logger
   .createLogger('http_extension')
   .createChildLogger('error_handler');
 
+// NOTE: The function signature must be exact, or express will not recognize it as an error handler
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function errorHandler(error: BaseError | Error, request: Request, response: Response, next: NextFunction): void {
 
   const isFromEssentialProjects = isEssentialProjectsError(error);


### PR DESCRIPTION
## Changes

1. Remove unnecessary usages of `any`
2. Remove eslint rule overrides
3. Remove injection of class parameters
4. Reorder functions: public - protected - private
5. Remove unnecessary hooks

**Breaking Changes**:

1. Remove public exposure of ioc container, internal routers and socket endpoints
2. Remove protected `invokeAsPromiseIfPossible` helper function 
3. Make internal router- and socket- initializer functions private. Includes the following:
    - `initializeRouter` (Override `initializeRouters` instead)
    - `bindRoute` (Purely internal hook that should not be overwritten under any circumstances)
    - `initializeSocketEndpoint` (Override `initializeSocketEndpoints` instead)

## Issues

Part of https://github.com/process-engine/bpmn-studio/issues/1907

PR: #1

## How to test the changes

- Some of the internal hooks should no longer be exposed
- Everything else should work as before